### PR TITLE
feat: add menu.border to light and dark themes

### DIFF
--- a/themes/monospace-dark.json
+++ b/themes/monospace-dark.json
@@ -186,6 +186,7 @@
 		"panelSection.border": "#333e4fff",
 		"menu.foreground": "#d9dfe7ff",
 		"menu.background": "#10151dff",
+		"menu.border": "#3d495aff",
 		"menu.selectionForeground": "#d9dfe7ff",
 		"menu.selectionBackground": "#1f2939ff",
 		"menu.separatorBackground": "#333e4fff",

--- a/themes/monospace-light.json
+++ b/themes/monospace-light.json
@@ -186,6 +186,7 @@
 		"panelSection.border": "#d9dfe7ff",
 		"menu.foreground": "#333e4fff",
 		"menu.background": "#f4f7fdff",
+		"menu.border": "#bfc7d2ff",
 		"menu.selectionForeground": "#333e4fff",
 		"menu.selectionBackground": "#d9dfe7ff",
 		"menu.separatorBackground": "#d9dfe7ff",


### PR DESCRIPTION
I noticed that Project IDX default themes have borders around menus, while this theme doesn't. So I got the colors from Project IDX (by using the command "Developer: Generate Color Theme From Current Settings" on both dark and light themes) and added to this repo.

# Current (dark theme)

![Menu on Monospace Theme](https://github.com/keksiqc/monospace-theme/assets/20052157/23f803df-2c47-419b-9ac5-a44d3b65ecf1)

# New

![Menu with border on Monospace Theme](https://github.com/keksiqc/monospace-theme/assets/20052157/783a6bb7-f945-4db1-92cd-9a1701e56be2)

# On Project IDX, for comparison

![Menu on Project IDX](https://github.com/keksiqc/monospace-theme/assets/20052157/01e0bb2a-7fb7-4cc1-aafd-6c65dc402eec)